### PR TITLE
grunt build before grunt test

### DIFF
--- a/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
+++ b/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
@@ -1,5 +1,8 @@
 package com.github.trecloux.yeoman;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.maven.plugin.AbstractMojo;
@@ -7,9 +10,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import java.io.File;
-import java.io.IOException;
 
 /*
  * Copyright 2013 Thomas Recloux
@@ -69,10 +69,10 @@ public class YeomanMojo extends AbstractMojo {
     }
     void grunt() throws MojoExecutionException {
         logToolVersion("grunt");
+        logAndExecuteCommand("grunt " + gruntBuildArgs);
         if (!skipTests) {
             logAndExecuteCommand("grunt " + gruntTestArgs);
         }
-        logAndExecuteCommand("grunt " + gruntBuildArgs);
     }
 
     void logToolVersion(final String toolName) throws MojoExecutionException {


### PR DESCRIPTION
Не работают тесты на проекте с angularjs и typescript, так как  *.js файлов скомпилированных из *.ts нет до шага build, но они подключаются во время тестов. Ошибки имеют вид: 
Controller: MainCtrl
        test to make Karma happy
	Error: [$injector:modulerr] Failed to instantiate module studioApp due to:
	Error: [$injector:nomod] Module 'studioApp' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.


Tests doesn't work on project with angularjs and typescript, because *.js files compiled from *.ts is not exist, but included in test. Exception:
Controller: MainCtrl
        test to make Karma happy
	Error: [$injector:modulerr] Failed to instantiate module studioApp due to:
	Error: [$injector:nomod] Module 'studioApp' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.

Sorry for my english.