### PR TITLE
Add new skipBuild property.

### DIFF
--- a/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
+++ b/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
@@ -33,6 +33,8 @@ public class YeomanMojo extends AbstractMojo {
     File yeomanProjectDirectory;
     @Parameter( defaultValue = "${os.name}", readonly = true)
     String osName;
+    @Parameter( property = "yo.build.skip", defaultValue = "false")
+    boolean skipBuild;
     @Parameter( property = "yo.test.skip", defaultValue = "false")
     boolean skipTests;
     @Parameter( property = "yo.skip", defaultValue = "false")
@@ -72,7 +74,9 @@ public class YeomanMojo extends AbstractMojo {
         if (!skipTests) {
             logAndExecuteCommand("grunt " + gruntTestArgs);
         }
-        logAndExecuteCommand("grunt " + gruntBuildArgs);
+        if(!skipBuild) {
+            logAndExecuteCommand("grunt " + gruntBuildArgs);
+        }
     }
 
     void logToolVersion(final String toolName) throws MojoExecutionException {

--- a/src/test/java/com/github/trecloux/yeoman/YeomanMojoTest.java
+++ b/src/test/java/com/github/trecloux/yeoman/YeomanMojoTest.java
@@ -56,7 +56,42 @@ public class YeomanMojoTest extends AbstractMojoTestCase {
                 "grunt build --no-color"
         );
     }
+    
+    public void test_should_skip_build_when_flag_set() throws Exception {
+        MavenProject project = getMavenProject("src/test/resources/test-mojo-default-pom.xml");
+        YeomanMojo yeomanMojo = (YeomanMojo) lookupConfiguredMojo(project, "build");
+        yeomanMojo.skipBuild = true;
 
+        List<String> commands = executeMojoAndCaptureCommands(yeomanMojo);
+
+        assertThat(commands).containsExactly(
+                "node --version",
+                "npm --version",
+                "npm install",
+                "bower --version",
+                "bower install --no-color",
+                "grunt --version",
+                "grunt test --no-color"
+        );
+    }
+
+    public void test_should_skip_tests_when_flag_set() throws Exception {
+        MavenProject project = getMavenProject("src/test/resources/test-mojo-default-pom.xml");
+        YeomanMojo yeomanMojo = (YeomanMojo) lookupConfiguredMojo(project, "build");
+        yeomanMojo.skipTests = true;
+
+        List<String> commands = executeMojoAndCaptureCommands(yeomanMojo);
+
+        assertThat(commands).containsExactly(
+                "node --version",
+                "npm --version",
+                "npm install",
+                "bower --version",
+                "bower install --no-color",
+                "grunt --version",
+                "grunt build --no-color"
+        );
+    }
 
     public void test_should_run_all_commands_with_custom_args() throws Exception {
         YeomanMojo yeomanMojo = (YeomanMojo) lookupMojo("build", "src/test/resources/test-mojo-configuration-pom.xml");


### PR DESCRIPTION
- New skipBuild property for skipping the 'grunt build' portion.
- Allows for fine grained control of execution, tying test and
  packaging pieces to different maven lifecycle phases.

This nicely allows for the following execution setup:

```
<executions>
    <execution>
        <id>build</id>
        <phase>prepare-package</phase>
        <goals>
            <goal>build</goal>
        </goals>
        <configuration>
            <skipTests>true</skipTests>
        </configuration>
    </execution>
    <execution>
        <id>test</id>
        <phase>test</phase>
        <goals>
            <goal>build</goal>
        </goals>
        <configuration>
            <skipBuild>true</skipBuild>
        </configuration>
    </execution>
</executions>
```

Which allows one, for example, to perform a test without waiting for all the packaging/build work to occur as well.
