### PR TITLE
Added Configuration Property for a bower-variant.

### DIFF
--- a/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
+++ b/src/main/java/com/github/trecloux/yeoman/YeomanMojo.java
@@ -42,6 +42,8 @@ public class YeomanMojo extends AbstractMojo {
 
     @Parameter( defaultValue = "install", required = true )
     String npmInstallArgs;
+    @Parameter(defaultValue = "bower",  required = true )
+    String bowerVariant;
     @Parameter( defaultValue = "install --no-color", required = true )
     String bowerInstallArgs;
     @Parameter( defaultValue = "grunt", required = true )
@@ -85,8 +87,8 @@ public class YeomanMojo extends AbstractMojo {
     }
 
     void bowerInstall() throws MojoExecutionException {
-        logToolVersion("bower");
-        logAndExecuteCommand("bower " + bowerInstallArgs);
+        logToolVersion(bowerVariant);
+        logAndExecuteCommand(bowerVariant+ " " + bowerInstallArgs);
     }
     void build() throws MojoExecutionException {
         logToolVersion(buildTool);

--- a/src/test/java/com/github/trecloux/yeoman/YeomanMojoTest.java
+++ b/src/test/java/com/github/trecloux/yeoman/YeomanMojoTest.java
@@ -102,8 +102,8 @@ public class YeomanMojoTest extends AbstractMojoTestCase {
                 "node --version",
                 "npm --version",
                 "npm arg1",
-                "bower --version",
-                "bower arg2",
+                "bower-art --version",
+                "bower-art arg2",
                 "grunt --version",
                 "grunt arg3",
                 "grunt arg4"

--- a/src/test/resources/test-mojo-configuration-pom.xml
+++ b/src/test/resources/test-mojo-configuration-pom.xml
@@ -15,6 +15,7 @@
                     <buildTool>grunt</buildTool>
                     <testArgs>arg3</testArgs>
                     <buildArgs>arg4</buildArgs>
+                    <bowerVariant>bower-art</bowerVariant>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Hi, 

we are using your plugin to build behind a firewall and are using artifactory for access to bower repositories. Artifactory works with a bower-variant called "bower-art" (https://www.npmjs.com/package/bower-art).
I have updated your plugin to support an optional parameter "bowerVariant".

Best Regards
Thorsten